### PR TITLE
Description of Input parameters in qualification Report

### DIFF
--- a/examples/minimal/input/master_quali_plan.json
+++ b/examples/minimal/input/master_quali_plan.json
@@ -51,6 +51,20 @@
                 }]
             }]
         },
+        "Inputs": [
+            {
+                "Project": "Midazolam",
+                "Type": "Compound",
+                "Name": "Midazolam",
+                "sectionId": 1
+            },
+            {
+                "Project": "Midazolam",
+                "Type": "Simulation",
+                "Name": "S1",
+                "sectionId": 2
+            }		
+		],
         "Sections": [
             {
                 "id": 1,

--- a/examples/minimal/reporting engine input/report-configuration-plan.json
+++ b/examples/minimal/reporting engine input/report-configuration-plan.json
@@ -111,6 +111,20 @@
                 }]
             }]
         },
+        "Inputs": [
+            {
+                "Project": "Midazolam",
+                "Type": "Compound",
+                "Name": "Midazolam",
+                "sectionId": 1
+            },
+            {
+                "Project": "Midazolam",
+                "Type": "Simulation",
+                "Name": "S1",
+                "sectionId": 2
+            }		
+		],		
         "Sections": [
             {
                 "id": 1,


### PR DESCRIPTION
What we have forgotten in the report configuration is description of the **input** parameters.
After discussion with users: like for the plots, inputs description should be assignable to report sections (chapters)