### PR TITLE
Fixes 89 global axes

### DIFF
--- a/snippets/qualification.code-snippets
+++ b/snippets/qualification.code-snippets
@@ -100,6 +100,35 @@
     ],
     "description": "Adds the default plot settings configuration (global or local)"
   },
+  "addAxesSettings":{
+    "scope": "json",
+    "prefix": "aas",
+    "body": [
+      "\"AxesSettings\": {",
+      "\"GOFMergedPlotsPredictedVsObserved\": [ ],",
+      "\"GOFMergedPlotsResidualsOverTime\": [ ],",
+      "\"ComparisonTimeProfile\": [ ],",
+      "\"DDIRatioPlotsPredictedVsObserved\": [ ],",
+      "\"DDIRatioPlotsResidualsVsObserved\": [ ],",
+      "\"PKRatioPlots\": [ ]",
+      "},",
+    ],
+    "description": "Adds the global axes settings skeleton"
+  },
+  "addAxisSettings" :{
+    "scope": "json",
+    "prefix": "aax",
+    "body": [
+      "{",
+      "\"Unit\": \"\",",
+      "\"Dimension\": \"\",",
+      "\"Type\": \"\",",
+      "\"GridLines\": false,",
+      "\"Scaling\": \"Linear\"",
+      "}"
+    ],
+    "description": "Adds axis settings content"
+  },
   "addAllPlot": {
     "scope": "json",
     "prefix": "aap",

--- a/snippets/qualification.code-snippets
+++ b/snippets/qualification.code-snippets
@@ -9,6 +9,7 @@
       "\"Projects\": [],",
       "\"ObservedDataSets\": [],",
       "\"Plots\": {",
+      "\"AxesSettings\": {},",
       "\"AllPlots\": [],",
       "\"GOFMergedPlots\": [],",
       "\"ComparisonTimeProfilePlots\": [],",
@@ -100,34 +101,39 @@
     ],
     "description": "Adds the default plot settings configuration (global or local)"
   },
-  "addAxesSettings":{
+  "addAxesSettings": {
     "scope": "json",
     "prefix": "aas",
     "body": [
-      "\"AxesSettings\": {",
       "\"GOFMergedPlotsPredictedVsObserved\": [ ],",
       "\"GOFMergedPlotsResidualsOverTime\": [ ],",
       "\"ComparisonTimeProfile\": [ ],",
       "\"DDIRatioPlotsPredictedVsObserved\": [ ],",
       "\"DDIRatioPlotsResidualsVsObserved\": [ ],",
-      "\"PKRatioPlots\": [ ]",
-      "},",
+      "\"PKRatioPlots\": [ ]"
     ],
     "description": "Adds the global axes settings skeleton"
   },
-  "addAxisSettings" :{
+  "addAxisSettings": {
     "scope": "json",
-    "prefix": "aax",
+    "prefix": "axy",
     "body": [
       "{",
-      "\"Unit\": \"\",",
-      "\"Dimension\": \"\",",
-      "\"Type\": \"\",",
+      "\"Type\": \"X\",",
+      "\"Dimension\": \"${1}\",",
+      "\"Unit\": \"${2}\",",
       "\"GridLines\": false,",
       "\"Scaling\": \"Linear\"",
+      "},",
+      "{",
+      "\"Type\": \"Y\",",
+      "\"Dimension\": \"${3}\",",
+      "\"Unit\": \"${4}\",",
+      "\"GridLines\": false,",
+      "\"Scaling\": \"Log\"",
       "}"
     ],
-    "description": "Adds axis settings content"
+    "description": "Adds axes X and Y settings content"
   },
   "addAllPlot": {
     "scope": "json",
@@ -252,11 +258,11 @@
       "\"TimeUnit\":  \"${10}\"",
       "},",
       "\"SimulationDDI\": {",
-        "\"Project\":  \"${6:<Enter Project Id>}\",",
-        "\"Simulation\":  \"${11:<Enter Simulation Name>}\",",
-        "\"StartTime\":  ${8:<Enter Start Time>},",
-        "\"EndTime\":  ${9:<Enter End Time>},",
-        "\"TimeUnit\":  \"${10}\"",
+      "\"Project\":  \"${6:<Enter Project Id>}\",",
+      "\"Simulation\":  \"${11:<Enter Simulation Name>}\",",
+      "\"StartTime\":  ${8:<Enter Start Time>},",
+      "\"EndTime\":  ${9:<Enter End Time>},",
+      "\"TimeUnit\":  \"${10}\"",
       "}",
       "}"
     ],


### PR DESCRIPTION
@Yuri05 I have implemented snippets for axes settings global and one single Axis

However I don;t think this is the right approach for global settings
if feels like it should be an array of axis with a plotType instead

```
 "DDIRatioPlotsResidualsVsObserved": [
        {
          "Unit": "",
          "Dimension": "Dimensionless",
          "Type": "X",
          "GridLines": false,
          "Scaling": "Log"
        },
        {
          "Unit": "",
          "Dimension": "Dimensionless",
          "Type": "Y",
          "GridLines": false,
          "Scaling": "Linear"
        }
      ],
      "GOFMergedPlotsPredictedVsObserved": [
        {
          "Unit": "µg/ml",
          "Dimension": "Concentration (mass)",
          "Type": "X",
          "GridLines": false,
          "Scaling": "Log"
        },
        {
          "Unit": "µg/ml",
          "Dimension": "Concentration (mass)",
          "Type": "Y",
          "GridLines": false,
          "Scaling": "Log"
        }
      ],
```

would become
```
[
   {
          "Unit": "",
          "Dimension": "Dimensionless",
          "Type": "X",
          "GridLines": false,
          "Scaling": "Log",
          "PlotType": "DDIRatioPlotsResidualsVsObserved"
        },
        {
          "Unit": "",
          "Dimension": "Dimensionless",
          "Type": "Y",
          "GridLines": false,
          "Scaling": "Linear"
          "PlotType": "DDIRatioPlotsResidualsVsObserved"
        },
  {
          "Unit": "µg/ml",
          "Dimension": "Concentration (mass)",
          "Type": "X",
          "GridLines": false,
          "Scaling": "Log"
          "PlotType": "GOFMergedPlotsPredictedVsObserved"
        },
        {
          "Unit": "µg/ml",
          "Dimension": "Concentration (mass)",
          "Type": "Y",
          "GridLines": false,
          "Scaling": "Log"
          "PlotType": "GOFMergedPlotsPredictedVsObserved"
        }

]
```