### PR TITLE
Fixes #101 Remove SimulationParameters

### DIFF
--- a/schemas/OSP_Qualification_Plan_Schema.json
+++ b/schemas/OSP_Qualification_Plan_Schema.json
@@ -208,8 +208,22 @@
           "required": ["Type"]
         }
       ]
-    }
+    },
 
+    "simulationParameters": {
+      "type": "array",
+      "items": 
+        {
+          "type": "object",
+          "properties": {
+            "Simulation": { "$ref": "#/definitions/nonEmptyString" },
+            "Path": { "$ref": "#/definitions/nonEmptyString" },
+            "SourceProject": { "$ref": "#/definitions/nonEmptyString" },
+            "SourceSimulation": { "$ref": "#/definitions/nonEmptyString" }
+          },
+          "required": ["Simulation", "Path", "SourceProject", "SourceSimulation"]
+        }
+    }
   },
 
   "type": "object",
@@ -238,21 +252,6 @@
                     "Project": { "$ref": "#/definitions/nonEmptyString" }
                   },
                   "required": ["Type", "Name", "Project"]
-                }
-            },
-
-            "SimulationParameters": {
-              "type": "array",
-              "items": 
-                {
-                  "type": "object",
-                  "properties": {
-                    "Simulation": { "$ref": "#/definitions/nonEmptyString" },
-                    "Path": { "$ref": "#/definitions/nonEmptyString" },
-                    "SourceProject": { "$ref": "#/definitions/nonEmptyString" },
-                    "SourceSimulation": { "$ref": "#/definitions/nonEmptyString" }
-                  },
-                  "required": ["Simulation", "Path", "SourceProject", "SourceSimulation"]
                 }
             }
           },


### PR DESCRIPTION
I moved _SimulationParameters_ to the _definitions_ part of the schema and removed it from projects.
Thus SimulationParameters cannot be defined in qualification plans anymore.

If we would like to reactivate it later, we would just need to add
`"SimulationParameters": { "$ref": "#/definitions/simulationParameters" }`
under Projects.